### PR TITLE
accept multi range conditions in input queries

### DIFF
--- a/lib/nose/backend.rb
+++ b/lib/nose/backend.rb
@@ -174,7 +174,7 @@ module NoSE
               Condition.new field, :'=', result[field.id]
             end
 
-            unless @range_fields.empty?
+            unless @range_fields.to_a.empty?
               operator = conditions.each_value.find(&:range?).operator
               result_condition << Condition.new(@range_fields, operator,
                                                 result[@range_fields.id])

--- a/lib/nose/backend.rb
+++ b/lib/nose/backend.rb
@@ -174,7 +174,7 @@ module NoSE
               Condition.new field, :'=', result[field.id]
             end
 
-            unless @range_field.nil?
+            unless @range_field.empty?
               operator = conditions.each_value.find(&:range?).operator
               result_condition << Condition.new(@range_field, operator,
                                                 result[@range_field.id])

--- a/lib/nose/backend.rb
+++ b/lib/nose/backend.rb
@@ -154,7 +154,7 @@ module NoSE
           @next_step = next_step
 
           @eq_fields = step.eq_filter
-          @range_field = step.range_filter
+          @range_fields = step.range_filter
         end
 
         protected
@@ -174,10 +174,10 @@ module NoSE
               Condition.new field, :'=', result[field.id]
             end
 
-            unless @range_field.empty?
+            unless @range_fields.empty?
               operator = conditions.each_value.find(&:range?).operator
-              result_condition << Condition.new(@range_field, operator,
-                                                result[@range_field.id])
+              result_condition << Condition.new(@range_fields, operator,
+                                                result[@range_fields.id])
             end
 
             result_condition
@@ -233,9 +233,9 @@ module NoSE
 
           # XXX: This assumes that the range filter step is the same as
           #      the one in the query, which is always true for now
-          range = @step.range && conditions.each_value.find(&:range?)
+          ranges = @step.ranges && conditions.each_value.find(&:range?)
 
-          results.select! { |row| include_row?(row, eq_conditions, range) }
+          results.select! { |row| include_row?(row, eq_conditions, ranges) }
 
           results
         end

--- a/lib/nose/backend/cassandra.rb
+++ b/lib/nose/backend/cassandra.rb
@@ -312,7 +312,7 @@ module NoSE
           where = @eq_fields.map do |field|
             "\"#{field.id}\" = ?"
           end.join ' AND '
-          unless @range_fields.empty?
+          unless @range_fields.to_a.empty?
             condition = conditions.each_value.find(&:range?)
             where << " AND \"#{condition.field.id}\" #{condition.operator} ?"
           end

--- a/lib/nose/backend/cassandra.rb
+++ b/lib/nose/backend/cassandra.rb
@@ -312,7 +312,7 @@ module NoSE
           where = @eq_fields.map do |field|
             "\"#{field.id}\" = ?"
           end.join ' AND '
-          unless @range_field.empty?
+          unless @range_fields.empty?
             condition = conditions.each_value.find(&:range?)
             where << " AND \"#{condition.field.id}\" #{condition.operator} ?"
           end

--- a/lib/nose/backend/cassandra.rb
+++ b/lib/nose/backend/cassandra.rb
@@ -312,7 +312,7 @@ module NoSE
           where = @eq_fields.map do |field|
             "\"#{field.id}\" = ?"
           end.join ' AND '
-          unless @range_field.nil?
+          unless @range_field.empty?
             condition = conditions.each_value.find(&:range?)
             where << " AND \"#{condition.field.id}\" #{condition.operator} ?"
           end

--- a/lib/nose/backend/file.rb
+++ b/lib/nose/backend/file.rb
@@ -98,10 +98,12 @@ module NoSE
         # Check if a row matches the given condition on the range predicate
         # @return [Boolean]
         def row_matches_range?(row, conditions)
-          return true if @range_field.nil?
+          return true if @range_fields.nil?
 
-          range_cond = conditions.find { |c| c.field == @range_field }
-          row[@range_field.id].send range_cond.operator, range_cond.value
+          range_cond = conditions.find { |c| c.field == @range_fields }
+          @range_fields.each do |range_field|
+            row[range_field.id].send range_cond.operator, range_cond.value
+          end
         end
       end
 

--- a/lib/nose/enumerator.rb
+++ b/lib/nose/enumerator.rb
@@ -19,7 +19,7 @@ module NoSE
       range = if query.range_field.nil?
                 query.order
               else
-                [query.range_field] + query.order
+                ([query.range_field] + query.order).flatten(1)
               end
 
       eq = query.eq_fields.group_by(&:parent)

--- a/lib/nose/enumerator.rb
+++ b/lib/nose/enumerator.rb
@@ -16,10 +16,10 @@ module NoSE
     def indexes_for_query(query)
       @logger.debug "Enumerating indexes for query #{query.text}"
 
-      range = if query.range_field.nil?
+      range = if query.range_fields.nil?
                 query.order
               else
-                ([query.range_field] + query.order).flatten(1)
+                ([query.range_fields] + query.order).flatten(1)
               end
 
       eq = query.eq_fields.group_by(&:parent)

--- a/lib/nose/indexes.rb
+++ b/lib/nose/indexes.rb
@@ -227,8 +227,8 @@ module NoSE
       order_fields = @eq_fields.select do |field|
         field.parent != hash_entity
       end + @order
-      if @range_field && !@order.include?(@range_field)
-        order_fields += @range_field
+      if @range_fields && !@order.include?(@range_fields)
+        order_fields += @range_fields
       end
 
       # Ensure we include IDs of the final entity

--- a/lib/nose/indexes.rb
+++ b/lib/nose/indexes.rb
@@ -228,7 +228,7 @@ module NoSE
         field.parent != hash_entity
       end + @order
       if @range_field && !@order.include?(@range_field)
-        order_fields << @range_field
+        order_fields += @range_field
       end
 
       # Ensure we include IDs of the final entity

--- a/lib/nose/plans/execution_plan.rb
+++ b/lib/nose/plans/execution_plan.rb
@@ -208,17 +208,17 @@ module NoSE
 
         step = Plans::IndexLookupPlanStep.new index
         eq_fields = Set.new
-        range_field = nil
+        range_fields = nil
         conditions.each do |field, operator|
           if operator == :==
             eq_fields.add field
           else
-            range_field = field
+            range_fields = field
           end
         end
 
         step.instance_variable_set :@eq_filter, eq_fields
-        step.instance_variable_set :@range_filter, range_field
+        step.instance_variable_set :@range_filter, range_fields
 
         # XXX No ordering supported for now
         step.instance_variable_set :@order_by, []
@@ -236,7 +236,7 @@ module NoSE
         cardinality = index.per_hash_count * state.hash_cardinality
         state.cardinality = Cardinality.filter cardinality,
                                                eq_fields - index.hash_fields,
-                                               range_field
+                                               range_fields
 
         step.state = state
 

--- a/lib/nose/plans/filter.rb
+++ b/lib/nose/plans/filter.rb
@@ -25,7 +25,7 @@ module NoSE
       end
 
       def hash
-        [@eq.map(&:id), @range.nil? ? nil : @range.id].hash
+        [@eq.map(&:id), @range.nil? ? nil : @range.map(&:id)].hash
       end
 
       # :nocov:
@@ -54,9 +54,9 @@ module NoSE
       def self.filter_fields(parent, state)
         eq_filter = state.eq.select { |field| parent.fields.include? field }
         filter_fields = eq_filter.dup
-        if state.range && parent.fields.include?(state.range)
+        if state.range && parent.fields >= Set.new(state.range)
           range_filter = state.range
-          filter_fields << range_filter
+          filter_fields += range_filter
         else
           range_filter = nil
         end

--- a/lib/nose/plans/index_lookup.rb
+++ b/lib/nose/plans/index_lookup.rb
@@ -175,7 +175,7 @@ module NoSE
       # @return [Array<Fields::Field>]
       def range_order_prefix
         order_prefix = (@state.eq - @index.hash_fields) & @index.order_fields
-        order_prefix << @state.range unless @state.range.nil?
+        order_prefix += @state.range unless @state.range.nil?
         order_prefix = order_prefix.zip(@index.order_fields)
         order_prefix.take_while { |x, y| x == y }.map(&:first)
       end
@@ -279,7 +279,7 @@ module NoSE
 
         # Find fields which are filtered by the index
         @eq_filter = @index.hash_fields + (@state.eq & order_prefix)
-        if order_prefix.include?(@state.range)
+        if order_prefix and order_prefix >= Set.new(@state.range)
           @range_filter = @state.range
           @state.range = nil
         else

--- a/lib/nose/plans/index_lookup.rb
+++ b/lib/nose/plans/index_lookup.rb
@@ -175,7 +175,7 @@ module NoSE
       # @return [Array<Fields::Field>]
       def range_order_prefix
         order_prefix = (@state.eq - @index.hash_fields) & @index.order_fields
-        order_prefix += @state.range unless @state.range.nil?
+        order_prefix += @state.ranges unless @state.ranges.nil?
         order_prefix = order_prefix.zip(@index.order_fields)
         order_prefix.take_while { |x, y| x == y }.map(&:first)
       end
@@ -279,9 +279,9 @@ module NoSE
 
         # Find fields which are filtered by the index
         @eq_filter = @index.hash_fields + (@state.eq & order_prefix)
-        if order_prefix and order_prefix >= Set.new(@state.range)
-          @range_filter = @state.range
-          @state.range = nil
+        if order_prefix and order_prefix >= Set.new(@state.ranges)
+          @range_filter = @state.ranges
+          @state.ranges = nil
         else
           @range_filter = nil
         end

--- a/lib/nose/plans/query_planner.rb
+++ b/lib/nose/plans/query_planner.rb
@@ -66,7 +66,7 @@ module NoSE
       # @return [Array<Field>]
       def fields_for_graph(graph, include_entity, select: false)
         graph_fields = @eq + @order_by
-        graph_fields << @range unless @range.nil?
+        graph_fields += @range unless @range.nil?
 
         # If necessary, include ALL the fields which should be selected,
         # otherwise we can exclude fields from leaf entity sets since

--- a/lib/nose/plans/sort.rb
+++ b/lib/nose/plans/sort.rb
@@ -33,7 +33,7 @@ module NoSE
       # @return [SortPlanStep]
       def self.apply(parent, state)
         fetched_all_ids = state.fields.none? { |f| f.is_a? Fields::IDField }
-        resolved_predicates = state.eq.empty? && state.range.nil?
+        resolved_predicates = state.eq.empty? && state.ranges.nil?
         can_order = !(state.order_by.to_set & parent.fields).empty?
         return nil unless fetched_all_ids && resolved_predicates && can_order
 

--- a/lib/nose/plans/update_planner.rb
+++ b/lib/nose/plans/update_planner.rb
@@ -224,7 +224,7 @@ module NoSE
             else
               cardinality = Cardinality.filter index.entries,
                                                statement.eq_fields,
-                                               statement.range_field
+                                               statement.range_fields
             end
           else
             # Get the cardinality of the last step to use for the update state

--- a/lib/nose/serialize.rb
+++ b/lib/nose/serialize.rb
@@ -271,7 +271,7 @@ module NoSE
     # Represent the filtered fields in filter plan steps
     class FilterStepRepresenter < PlanStepRepresenter
       collection :eq, decorator: FieldRepresenter
-      property :range, decorator: FieldRepresenter
+      property :ranges, decorator: FieldRepresenter
     end
 
     # Represent the sorted fields in filter plan steps

--- a/lib/nose/statements.rb
+++ b/lib/nose/statements.rb
@@ -49,8 +49,8 @@ module NoSE
     def populate_conditions(params)
       @conditions = params[:conditions]
       @eq_fields = conditions.each_value.reject(&:range?).map(&:field).to_set
-      @range_field = conditions.each_value.find(&:range?)
-      @range_field = @range_field.field unless @range_field.nil?
+      @range_field = conditions.each_value.select(&:range?)
+      @range_field = @range_field.map{|f| f.field} unless @range_field.nil?
     end
 
     def self.included(base)

--- a/lib/nose/statements.rb
+++ b/lib/nose/statements.rb
@@ -49,8 +49,8 @@ module NoSE
     def populate_conditions(params)
       @conditions = params[:conditions]
       @eq_fields = conditions.each_value.reject(&:range?).map(&:field).to_set
-      @range_field = conditions.each_value.select(&:range?)
-      @range_field = @range_field.map{|f| f.field} unless @range_field.nil?
+      @range_fields = conditions.each_value.select(&:range?)
+      @range_fields = @range_fields.map{|f| f.field} unless @range_fields.nil?
     end
 
     def self.included(base)
@@ -274,7 +274,7 @@ module NoSE
   # A CQL statement and its associated data
   class Statement
     attr_reader :entity, :key_path, :label, :graph,
-                :group, :text, :eq_fields, :range_field, :comment
+                :group, :text, :eq_fields, :range_fields, :comment
 
     # Parse either a query or an update
     def self.parse(text, model, group: nil, label: nil, support: false)

--- a/lib/nose/util.rb
+++ b/lib/nose/util.rb
@@ -168,7 +168,7 @@ class Cardinality
   # Update the cardinality based on filtering implicit to the index
   # @return [Fixnum]
   def self.filter(cardinality, eq_filter, range_filter)
-    filtered = (range_filter.nil? ? 1.0 : 0.1) * cardinality
+    filtered = (range_filter.to_a.empty? ? 1.0 : 0.1) * cardinality
     filtered *= eq_filter.map do |field|
       1.0 / field.cardinality
     end.inject(1.0, &:*)

--- a/spec/planner_spec.rb
+++ b/spec/planner_spec.rb
@@ -173,8 +173,10 @@ module NoSE
 
         tree = planner.find_plans_for_query(query)
         expect(tree).to have(1).plan
+
+        # Filter step possibly has multiple field to filter
         expect(tree.first.last).to eq FilterPlanStep.new([],
-                                                         tweet['Timestamp'])
+                                                         [tweet['Timestamp']])
       end
 
       context 'when updating cardinality' do

--- a/spec/statements_spec.rb
+++ b/spec/statements_spec.rb
@@ -1,7 +1,7 @@
 module NoSE
   shared_examples 'a statement' do
     it 'tracks the range field' do
-      expect(statement.range_field).to eq tweet['Timestamp']
+      expect(statement.range_field.first).to eq tweet['Timestamp']
     end
 
     it 'tracks fields used in equality predicates' do

--- a/spec/statements_spec.rb
+++ b/spec/statements_spec.rb
@@ -1,7 +1,7 @@
 module NoSE
   shared_examples 'a statement' do
     it 'tracks the range field' do
-      expect(statement.range_field.first).to eq tweet['Timestamp']
+      expect(statement.range_fields.first).to eq tweet['Timestamp']
     end
 
     it 'tracks fields used in equality predicates' do

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -146,7 +146,7 @@ describe Cardinality do
 
   it 'uses a static estimate for range filters' do
     cardinality = Cardinality.filter tweet.count, [tweet['Body']],
-                                     tweet['Timestamp']
+                                     [tweet['Timestamp']]
 
     expect(cardinality).to eq(20)
   end


### PR DESCRIPTION
## background 

NoSE ignores 2nd or later range conditions in a query because the query with 2 or more range condition is inefficient.
And if the query has 2 or more range conditions and some fields in range conditions are not included in SELECT clause, the fields did not appear in the output.

```
Q 'SELECT items.id, items.name ' \
      'FROM items '\
      'WHERE items.id = ? AND ' \
              'items.quantity >= ? AND '\
              'items.nb_of_bids >= ? -- 7'
```
->
```
Indexes
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
i3137541448 [items.id] [items.quantity] → [items.name] $860000 Graph(nodes: items, edges: {})
```

'nb_of_bids' does not appear in output.

## changes

Allow NoSE to deal with 2 or more range conditions.
