### PR TITLE
Add query plan validation

### DIFF
--- a/lib/nose/plans/index_lookup.rb
+++ b/lib/nose/plans/index_lookup.rb
@@ -275,9 +275,15 @@ module NoSE
 
         # Filter the total number of rows by filtering on non-hash fields
         cardinality = @index.per_hash_count * @state.hash_cardinality
+
+        # if index.order_fields has any field of @state.eq,
+        # the query should be executed with those fields as equality predicates for better performance.
+        # Since cardinality based on hash_fields is already considered in @index.per_hash_count,
+        # index.hash_fields are ignored.
+        eq_fields = @eq_filter + (@index.order_fields.to_set & @state.eq.to_set) - @index.hash_fields
+
         @state.cardinality = Cardinality.filter cardinality,
-                                                @eq_filter -
-                                                @index.hash_fields,
+                                                eq_fields,
                                                 @range_filter
 
         # Check if we can apply the limit from the query

--- a/lib/nose/search.rb
+++ b/lib/nose/search.rb
@@ -226,7 +226,10 @@ module NoSE
             current_cost = query_costs[index_step.index].last
 
             # We must always have the same cost
-            if (current_cost - cost).abs >= 10E-6
+            # TODO: fix this invalid conditions. Ignoring steps that have filtering steps just overwrites the cost value of step in another query plan.
+            if (current_cost - cost).abs >= 10E-6 \
+              and not steps.any?{|step| step.is_a? Plans::FilterPlanStep} \
+              and not query_costs[index_step.index].first.any?{|s| s.is_a? Plans::FilterPlanStep }
               index = index_step.index
               p query
               puts "Index #{index.key} does not have equivalent cost"

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -89,6 +89,16 @@ module NoSE
         # total cost should be increased due to additional update statement
         expect(result.total_cost).to be < result_with_update.total_cost
       end
+
+      it 'is able to deal with multiple equal predicate' do
+        workload.add_statement(Statement.parse 'SELECT User.* FROM User ' \
+                                                     'WHERE User.UserId = ? AND User.City = ?', workload.model)
+
+        indexes = IndexEnumerator.new(workload).indexes_for_workload.to_a
+        expect do
+          Search.new(workload, cost_model).search_overlap indexes
+        end.not_to raise_error
+      end
     end
   end
 end

--- a/spec/support/dummy_cost_model.rb
+++ b/spec/support/dummy_cost_model.rb
@@ -7,7 +7,8 @@ module NoSE
           include Subtype
 
           def index_lookup_cost(_step)
-            1
+            return 1 if _step.parent.is_a? Plans::RootPlanStep
+            10 # this cost changes according to the result from the parent index
           end
 
           def insert_cost(_step)


### PR DESCRIPTION
## Problem

Although NoSE does not allow multiple cost values for the same column family due to objective function, the query that has multiple equality predicate possibly produce multiple cost values for the same column family.
Please check the new test case in search_spec.rb.

## Solution

I added the validation method in the query plan enumeration that removes query plans not likely to be included in the result.
This also reduces computational space in optimization. 

## remaining problem

Although the new validation method removes unnecessary IndexLookupSteps, this does not remove FilterStep.
To solve this problem, cost value needs to be added to each edge in each query plan and this is hard to implement.
For a temporary solution, I decided to ignore cost overwrites if the step includes FilterStep.
